### PR TITLE
Invalid escape sequence warnings in regex patterns

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -385,7 +385,8 @@ class DNB_DE(Source):
                                     raise Exception("Access currently unavailable")
 
                                 comments = re.sub(
-                                    b'(\s|<br>|<p>|\n)*Angaben aus der Verlagsmeldung(\s|<br>|<p>|\n)*(<h3>.*?</h3>)*(\s|<br>|<p>|\n)*', b'', comments, flags=re.IGNORECASE)
+                                    r'(\s|<br>|<p>|\n)*Angaben aus der Verlagsmeldung(\s|<br>|<p>|\n)*(<h3>.*?</h3>)*(\s|<br>|<p>|\n)*',
+                                    '', comments, flags=re.IGNORECASE)
                                 book['comments'] = sanitize_comments_html(comments)
                                 log.info('[856.u] Got Comments: %s' % book['comments'])
                                 break

--- a/__init__.py
+++ b/__init__.py
@@ -380,14 +380,18 @@ class DNB_DE(Source):
                             try:
                                 comments = br.open_novisit(url, timeout=30).read()
 
+                                # Decode bytes to string for processing
+                                comments_text = comments.decode('utf-8')
+
                                 # Skip service outage information web page
-                                if comments.decode('utf-8').find('Zugriff derzeit nicht möglich // Access currently unavailable') != -1:
+                                if 'Zugriff derzeit nicht möglich // Access currently unavailable' in comments_text:
                                     raise Exception("Access currently unavailable")
 
-                                comments = re.sub(
+                                # Process the text version
+                                comments_text = re.sub(
                                     r'(\s|<br>|<p>|\n)*Angaben aus der Verlagsmeldung(\s|<br>|<p>|\n)*(<h3>.*?</h3>)*(\s|<br>|<p>|\n)*',
-                                    '', comments, flags=re.IGNORECASE)
-                                book['comments'] = sanitize_comments_html(comments)
+                                    '', comments_text, flags=re.IGNORECASE)
+                                book['comments'] = sanitize_comments_html(comments_text)
                                 log.info('[856.u] Got Comments: %s' % book['comments'])
                                 break
                             except Exception as e:


### PR DESCRIPTION
When running the DNB_DE plugin with Calibre, multiple SyntaxWarnings are shown about invalid escape sequences in regular expressions:

```
calibre_plugins.DNB_DE.__init__:178: SyntaxWarning: invalid escape sequence '\('
calibre_plugins.DNB_DE.__init__:213: SyntaxWarning: invalid escape sequence '\d'
calibre_plugins.DNB_DE.__init__:269: SyntaxWarning: invalid escape sequence '\d'
calibre_plugins.DNB_DE.__init__:274: SyntaxWarning: invalid escape sequence '\['
calibre_plugins.DNB_DE.__init__:341: SyntaxWarning: invalid escape sequence '\['
calibre_plugins.DNB_DE.__init__:351: SyntaxWarning: invalid escape sequence '\['
calibre_plugins.DNB_DE.__init__:362: SyntaxWarning: invalid escape sequence '\['
calibre_plugins.DNB_DE.__init__:388: SyntaxWarning: invalid escape sequence '\s'
calibre_plugins.DNB_DE.__init__:464: SyntaxWarning: invalid escape sequence '\d'
calibre_plugins.DNB_DE.__init__:464: SyntaxWarning: invalid escape sequence '\d'
calibre_plugins.DNB_DE.__init__:466: SyntaxWarning: invalid escape sequence '\d'
calibre_plugins.DNB_DE.__init__:473: SyntaxWarning: invalid escape sequence '\d'
calibre_plugins.DNB_DE.__init__:482: SyntaxWarning: invalid escape sequence '\d'
calibre_plugins.DNB_DE.__init__:507: SyntaxWarning: invalid escape sequence '\d'
calibre_plugins.DNB_DE.__init__:529: SyntaxWarning: invalid escape sequence '\d'
calibre_plugins.DNB_DE.__init__:553: SyntaxWarning: invalid escape sequence '\d'
calibre_plugins.DNB_DE.__init__:640: SyntaxWarning: invalid escape sequence '\d'
calibre_plugins.DNB_DE.__init__:640: SyntaxWarning: invalid escape sequence '\d'
calibre_plugins.DNB_DE.__init__:643: SyntaxWarning: invalid escape sequence '\d'
calibre_plugins.DNB_DE.__init__:652: SyntaxWarning: invalid escape sequence '\s'
calibre_plugins.DNB_DE.__init__:658: SyntaxWarning: invalid escape sequence '\s'
calibre_plugins.DNB_DE.__init__:675: SyntaxWarning: invalid escape sequence '\s'
calibre_plugins.DNB_DE.__init__:692: SyntaxWarning: invalid escape sequence '\s'
calibre_plugins.DNB_DE.__init__:698: SyntaxWarning: invalid escape sequence '\s'
calibre_plugins.DNB_DE.__init__:708: SyntaxWarning: invalid escape sequence '\s'
calibre_plugins.DNB_DE.__init__:719: SyntaxWarning: invalid escape sequence '\s'
calibre_plugins.DNB_DE.__init__:1027: SyntaxWarning: invalid escape sequence '\s'
calibre_plugins.DNB_DE.__init__:1038: SyntaxWarning: invalid escape sequence '\w'
calibre_plugins.DNB_DE.__init__:1054: SyntaxWarning: invalid escape sequence '\w'
calibre_plugins.DNB_DE.__init__:1057: SyntaxWarning: invalid escape sequence '\W'
calibre_plugins.DNB_DE.__init__:1066: SyntaxWarning: invalid escape sequence '\['
calibre_plugins.DNB_DE.__init__:1066: SyntaxWarning: invalid escape sequence '\-'
calibre_plugins.DNB_DE.__init__:1090: SyntaxWarning: invalid escape sequence '\+'
```
I tried to look at the warnings and fix them. For me, the plugin still worked after that, so I hope this pull request is of some use. I hope I did not do anything wrong here and make things worse :blush: